### PR TITLE
Add migration to align menu configuration tables

### DIFF
--- a/db/migrations/000013_update_menu_config_tables.down.sql
+++ b/db/migrations/000013_update_menu_config_tables.down.sql
@@ -1,0 +1,75 @@
+-- Revert menu configuration table adjustments
+
+-- Subtopics revert
+ALTER TABLE subtopics
+    DROP INDEX uq_subtopics_topic_name,
+    DROP INDEX idx_subtopics_topic_id;
+
+ALTER TABLE subtopics
+    ADD COLUMN sort_order INT NOT NULL DEFAULT 0 AFTER name,
+    MODIFY created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE subtopics
+    CHANGE name sub_topic_name VARCHAR(255) NOT NULL;
+
+ALTER TABLE subtopics
+    ADD INDEX idx_subtopics_topic (topic_id, sort_order);
+
+ALTER TABLE subtopics
+    ADD CONSTRAINT fk_subtopics_topic FOREIGN KEY (topic_id) REFERENCES topics(id) ON DELETE CASCADE;
+
+-- Topics revert
+ALTER TABLE topics
+    DROP INDEX uq_topics_lesson_name,
+    DROP INDEX idx_topics_lesson_id;
+
+ALTER TABLE topics
+    ADD COLUMN main_topic_name VARCHAR(255) NOT NULL AFTER name,
+    ADD COLUMN sort_order INT NOT NULL DEFAULT 0 AFTER main_topic_name,
+    MODIFY created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE topics SET main_topic_name = name;
+
+ALTER TABLE topics
+    CHANGE name topic_name VARCHAR(255) NOT NULL;
+
+ALTER TABLE topics
+    ADD INDEX idx_topics_lesson (lesson_id, sort_order);
+
+ALTER TABLE topics
+    ADD CONSTRAINT fk_topics_lesson FOREIGN KEY (lesson_id) REFERENCES lessons(id) ON DELETE CASCADE;
+
+-- Lessons revert
+ALTER TABLE lessons
+    DROP INDEX uq_lessons_subject_name,
+    DROP INDEX idx_lessons_subject_id;
+
+ALTER TABLE lessons
+    DROP COLUMN created_at;
+
+ALTER TABLE lessons
+    ADD COLUMN image_url VARCHAR(255) NOT NULL AFTER name;
+
+ALTER TABLE lessons
+    ADD CONSTRAINT lessons_ibfk_1 FOREIGN KEY (subject_id) REFERENCES subjects(id) ON DELETE CASCADE;
+
+-- Subjects revert
+ALTER TABLE subjects
+    DROP INDEX uq_subjects_grade_name,
+    DROP INDEX idx_subjects_grade_id;
+
+ALTER TABLE subjects
+    DROP COLUMN created_at;
+
+ALTER TABLE subjects
+    ADD CONSTRAINT subjects_ibfk_1 FOREIGN KEY (grade_id) REFERENCES grades(id) ON DELETE CASCADE;
+
+-- Grades revert
+ALTER TABLE grades
+    DROP INDEX uq_grades_name;
+
+ALTER TABLE grades
+    DROP COLUMN created_at;
+
+ALTER TABLE grades
+    CHANGE name grade VARCHAR(50) NOT NULL;

--- a/db/migrations/000013_update_menu_config_tables.up.sql
+++ b/db/migrations/000013_update_menu_config_tables.up.sql
@@ -1,0 +1,69 @@
+-- Align legacy menu configuration tables with new repository expectations
+
+-- Grades adjustments
+ALTER TABLE grades
+    CHANGE grade name VARCHAR(120) NOT NULL;
+
+ALTER TABLE grades
+    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER name;
+
+ALTER TABLE grades
+    ADD UNIQUE INDEX uq_grades_name (name);
+
+-- Subjects adjustments
+ALTER TABLE subjects
+    DROP FOREIGN KEY subjects_ibfk_1;
+
+ALTER TABLE subjects
+    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER name;
+
+CREATE UNIQUE INDEX uq_subjects_grade_name ON subjects (grade_id, name);
+CREATE INDEX idx_subjects_grade_id ON subjects (grade_id);
+
+-- Lessons adjustments
+ALTER TABLE lessons
+    DROP FOREIGN KEY lessons_ibfk_1;
+
+ALTER TABLE lessons
+    DROP COLUMN image_url;
+
+ALTER TABLE lessons
+    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER name;
+
+CREATE UNIQUE INDEX uq_lessons_subject_name ON lessons (subject_id, name);
+CREATE INDEX idx_lessons_subject_id ON lessons (subject_id);
+
+-- Topics adjustments
+ALTER TABLE topics
+    DROP FOREIGN KEY fk_topics_lesson;
+
+ALTER TABLE topics
+    DROP INDEX idx_topics_lesson;
+
+ALTER TABLE topics
+    CHANGE topic_name name VARCHAR(255) NOT NULL;
+
+ALTER TABLE topics
+    DROP COLUMN main_topic_name,
+    DROP COLUMN sort_order,
+    MODIFY created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE UNIQUE INDEX uq_topics_lesson_name ON topics (lesson_id, name);
+CREATE INDEX idx_topics_lesson_id ON topics (lesson_id);
+
+-- Subtopics adjustments
+ALTER TABLE subtopics
+    DROP FOREIGN KEY fk_subtopics_topic;
+
+ALTER TABLE subtopics
+    DROP INDEX idx_subtopics_topic;
+
+ALTER TABLE subtopics
+    CHANGE sub_topic_name name VARCHAR(255) NOT NULL;
+
+ALTER TABLE subtopics
+    DROP COLUMN sort_order,
+    MODIFY created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE UNIQUE INDEX uq_subtopics_topic_name ON subtopics (topic_id, name);
+CREATE INDEX idx_subtopics_topic_id ON subtopics (topic_id);


### PR DESCRIPTION
## Summary
- adjust grades, subjects, lessons, topics, and subtopics tables to match the menu config repository expectations, including renames, timestamps, and indexes
- add a down migration that restores the legacy schema layout and constraints

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9765b30c8832196ac4e9f0e3965d5