### PR TITLE
Add admin catalog endpoint and grade-subject filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ go run cmd/server/main.go
 
 API available at: http://localhost:8080/health
 
+### Test the admin catalog endpoint
+
+Once the server is running and connected to your MySQL instance, you can fetch the full catalog payload with:
+
+```bash
+curl -X GET "http://localhost:8080/api/v1/admin/catalog" \
+  -H "Accept: application/json"
+```
+
+This returns grades, subjects, grade-subject mappings, lessons, topics, and subtopics in a single response for frontend filtering.
+
 Run with Docker
 Build Image
 docker build -t sl-edu-service .

--- a/db/migrations/000016_grade_subjects.down.sql
+++ b/db/migrations/000016_grade_subjects.down.sql
@@ -1,0 +1,34 @@
+SET @subject_unique := (
+  SELECT INDEX_NAME
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'subjects'
+    AND INDEX_NAME = 'uq_subject_name'
+  LIMIT 1
+);
+SET @drop_subject_unique := IF(@subject_unique IS NOT NULL,
+  'ALTER TABLE subjects DROP INDEX uq_subject_name',
+  'SELECT 1'
+);
+PREPARE drop_subject_stmt FROM @drop_subject_unique;
+EXECUTE drop_subject_stmt;
+DEALLOCATE PREPARE drop_subject_stmt;
+
+SET @subject_grade_unique := (
+  SELECT INDEX_NAME
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'subjects'
+    AND INDEX_NAME = 'uq_subject_grade_name'
+  LIMIT 1
+);
+SET @add_subject_grade_unique := IF(@subject_grade_unique IS NULL,
+  'ALTER TABLE subjects ADD UNIQUE KEY uq_subject_grade_name (grade_id, name)',
+  'SELECT 1'
+);
+PREPARE add_subject_grade_stmt FROM @add_subject_grade_unique;
+EXECUTE add_subject_grade_stmt;
+DEALLOCATE PREPARE add_subject_grade_stmt;
+
+-- Drop junction
+DROP TABLE IF EXISTS grade_subjects;

--- a/db/migrations/000016_grade_subjects.up.sql
+++ b/db/migrations/000016_grade_subjects.up.sql
@@ -1,0 +1,34 @@
+-- Create junction table to map Grades ↔ Subjects (no FKs for loose coupling)
+CREATE TABLE IF NOT EXISTS grade_subjects (
+  grade_id   INT NOT NULL,
+  subject_id INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_grade_subject (grade_id, subject_id),
+  KEY idx_gs_grade (grade_id),
+  KEY idx_gs_subject (subject_id)
+);
+
+SET @subject_grade_unique := (
+  SELECT INDEX_NAME
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'subjects'
+    AND INDEX_NAME = 'uq_subject_grade_name'
+  LIMIT 1
+);
+SET @drop_subject_grade_unique := IF(@subject_grade_unique IS NOT NULL,
+  'ALTER TABLE subjects DROP INDEX uq_subject_grade_name',
+  'SELECT 1'
+);
+PREPARE drop_stmt FROM @drop_subject_grade_unique;
+EXECUTE drop_stmt;
+DEALLOCATE PREPARE drop_stmt;
+ALTER TABLE subjects ADD UNIQUE KEY uq_subject_name (name);
+
+-- Optional: if subjects.grade_id currently exists, keep it for compatibility now (do NOT drop here)
+
+-- Backfill grade_subjects from existing subjects rows that still carry grade_id
+INSERT IGNORE INTO grade_subjects (grade_id, subject_id, created_at)
+SELECT DISTINCT s.grade_id, s.id, COALESCE(s.created_at, NOW())
+FROM subjects s
+WHERE s.grade_id IS NOT NULL;

--- a/internal/handler/menuConfigHandler.go
+++ b/internal/handler/menuConfigHandler.go
@@ -16,22 +16,23 @@ import (
 )
 
 type (
-	Grade          = menuconfigmodels.Grade
-	GradeUpsert    = menuconfigmodels.GradeUpsert
-	Subject        = menuconfigmodels.Subject
-	SubjectUpsert  = menuconfigmodels.SubjectUpsert
-	Lesson         = menuconfigmodels.Lesson
-	LessonUpsert   = menuconfigmodels.LessonUpsert
-	Topic          = menuconfigmodels.Topic
-	TopicUpsert    = menuconfigmodels.TopicUpsert
-	Subtopic       = menuconfigmodels.Subtopic
-	SubtopicUpsert = menuconfigmodels.SubtopicUpsert
-	Tutor          = menuconfigmodels.Tutor
-	TutorUpsert    = menuconfigmodels.TutorUpsert
-	Year           = menuconfigmodels.Year
-	YearUpsert     = menuconfigmodels.YearUpsert
-	Tutorial       = menuconfigmodels.Tutorial
-	TutorialUpsert = menuconfigmodels.TutorialUpsert
+	Grade           = menuconfigmodels.Grade
+	GradeUpsert     = menuconfigmodels.GradeUpsert
+	Subject         = menuconfigmodels.Subject
+	SubjectUpsert   = menuconfigmodels.SubjectUpsert
+	CatalogResponse = menuconfigmodels.CatalogResponse
+	Lesson          = menuconfigmodels.Lesson
+	LessonUpsert    = menuconfigmodels.LessonUpsert
+	Topic           = menuconfigmodels.Topic
+	TopicUpsert     = menuconfigmodels.TopicUpsert
+	Subtopic        = menuconfigmodels.Subtopic
+	SubtopicUpsert  = menuconfigmodels.SubtopicUpsert
+	Tutor           = menuconfigmodels.Tutor
+	TutorUpsert     = menuconfigmodels.TutorUpsert
+	Year            = menuconfigmodels.Year
+	YearUpsert      = menuconfigmodels.YearUpsert
+	Tutorial        = menuconfigmodels.Tutorial
+	TutorialUpsert  = menuconfigmodels.TutorialUpsert
 )
 
 type PagedResponse[T any] = menuconfigmodels.PagedResponse[T]
@@ -44,9 +45,22 @@ func NewHandler(repo *repository.MenuConfigRepository) *Handler {
 	return &Handler{repo: repo}
 }
 
+func RegisterCatalogRoutes(group *gin.RouterGroup, db *sql.DB) {
+	repo := repository.NewMenuConfigRepository(db)
+	handler := NewHandler(repo)
+
+	registerCatalogRoutes(group, handler)
+}
+
+func registerCatalogRoutes(group *gin.RouterGroup, handler *Handler) {
+	group.GET("/catalog", handler.getCatalog)
+}
+
 func RegisterAdminMenuConfigRoutes(group *gin.RouterGroup, db *sql.DB) {
 	repo := repository.NewMenuConfigRepository(db)
 	handler := NewHandler(repo)
+
+	registerCatalogRoutes(group, handler)
 
 	group.GET("/grades", handler.listGrades)
 	group.POST("/grades", handler.createGrade)
@@ -95,6 +109,16 @@ func RegisterAdminMenuConfigRoutes(group *gin.RouterGroup, db *sql.DB) {
 	group.GET("/tutorials/:id", handler.getTutorial)
 	group.PUT("/tutorials/:id", handler.updateTutorial)
 	group.DELETE("/tutorials/:id", handler.deleteTutorial)
+}
+
+func (h *Handler) getCatalog(c *gin.Context) {
+	catalog, err := h.repo.FetchCatalog(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, catalog)
 }
 
 func (h *Handler) listGrades(c *gin.Context) {

--- a/internal/handlers/question_handler.go
+++ b/internal/handlers/question_handler.go
@@ -43,6 +43,11 @@ func (h *QuestionHandler) GetQuestions(c *gin.Context) {
 			filters["lessonId"] = id
 		}
 	}
+	if v := c.Query("subjectId"); v != "" {
+		if id, err := strconv.Atoi(v); err == nil {
+			filters["subjectId"] = id
+		}
+	}
 	if v := c.Query("gradeId"); v != "" {
 		if id, err := strconv.Atoi(v); err == nil {
 			filters["gradeId"] = id

--- a/internal/models/menuconfig/catalog.go
+++ b/internal/models/menuconfig/catalog.go
@@ -1,0 +1,16 @@
+package menuconfig
+
+type CatalogResponse struct {
+	Grades        []Grade        `json:"grades"`
+	Subjects      []Subject      `json:"subjects"`
+	GradeSubjects []GradeSubject `json:"gradeSubjects"`
+	Lessons       []Lesson       `json:"lessons"`
+	Topics        []Topic        `json:"topics"`
+	Subtopics     []Subtopic     `json:"subtopics"`
+}
+
+type GradeSubject struct {
+	GradeID   int64  `json:"gradeId"`
+	SubjectID int64  `json:"subjectId"`
+	CreatedAt string `json:"createdAt"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 
 	"github.com/gin-gonic/gin"
-	menuhandler "github.com/tharindulakmal/sl-edu-service/internal/handler"
+	menuconfig "github.com/tharindulakmal/sl-edu-service/internal/handler"
 	"github.com/tharindulakmal/sl-edu-service/internal/handlers"
 	"github.com/tharindulakmal/sl-edu-service/internal/repository"
 )
@@ -13,7 +13,8 @@ func RegisterRoutes(router *gin.Engine, db *sql.DB) {
 	api := router.Group("/api/v1")
 
 	admin := api.Group("/admin")
-	menuhandler.RegisterAdminMenuConfigRoutes(admin, db)
+	menuconfig.RegisterCatalogRoutes(admin, db)
+	menuconfig.RegisterAdminMenuConfigRoutes(admin, db)
 
 	// Grades
 	gradeRepo := repository.NewGradeRepository(db)


### PR DESCRIPTION
## Summary
- add the grade_subjects migration and backfill to standardize subject mappings with backward-compatible handling for legacy unique indexes
- implement catalog DTOs, repository fetch, and admin route to serve menu configuration data in one call
- update MCQ question list filtering to use grade-subject relationships and support subject-based queries
- document curl usage for testing the admin catalog endpoint

## Testing
- `go test ./...` *(hangs in this environment; aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68e36dd60a388321b0f2be002a1aeb9b